### PR TITLE
chore: regenerate README and fix whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-secretmanager</artifactId>
   </dependency>
+</dependencies>
 
 ```
 

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -42,8 +42,7 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-secretmanager</artifactId>
     </dependency>
-
-     <!-- [START_EXCLUDE] -->
+    <!-- [START_EXCLUDE] -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,23 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/java-secretmanager.git",
-        "sha": "d5ad8def2720cc75c615812230cccc22788e35b5"
+        "remote": "git@github.com:googleapis/java-secretmanager.git",
+        "sha": "e2a650019fe34394c258f7c43694351cf9f48adf"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c4e37010d74071851ff24121f522e802231ac86e",
-        "internalRef": "313460921"
+        "sha": "b789f790565ad7cc473571b0cf35dfbe6707f6a8",
+        "internalRef": "315933871"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "987270824bd26f6a8c716d5e2022057b8ae7b26e"
+        "sha": "a0ee80e0492a03b9b2bfefb5cca7eaf17bf10438"
       }
     }
   ],

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,7 +3,7 @@
     {
       "git": {
         "name": ".",
-        "remote": "git@github.com:googleapis/java-secretmanager.git",
+        "remote": "https://github.com/googleapis/java-secretmanager.git",
         "sha": "e2a650019fe34394c258f7c43694351cf9f48adf"
       }
     },


### PR DESCRIPTION
README content generator was updated in https://github.com/googleapis/synthtool/pull/624

This runs the generator and fixes whitespace.