### PR TITLE
docs(sample): removing unnecessary native-image-support dependency

### DIFF
--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -105,11 +105,6 @@
 
       <dependencies>
         <dependency>
-          <groupId>com.google.cloud</groupId>
-          <artifactId>native-image-support</artifactId>
-          <version>0.13.1</version>
-        </dependency>
-        <dependency>
           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>
           <version>5.8.2</version>


### PR DESCRIPTION
For GraalVM native image, GAX provides required metadata. We no longer need native-image-support-java module.